### PR TITLE
Added generic iterator methods

### DIFF
--- a/codespan-reporting/src/diagnostic.rs
+++ b/codespan-reporting/src/diagnostic.rs
@@ -182,10 +182,22 @@ impl<FileId> Diagnostic<FileId> {
         self.labels.append(&mut labels);
         self
     }
+    
+    /// Add some labels to the diagnostic.
+    pub fn with_labels_iter(mut self, labels: impl IntoIterator<Item = Label<FileId>>) -> Diagnostic<FileId> {
+        self.labels.extend(labels);
+        self
+    }
 
     /// Add some notes to the diagnostic.
     pub fn with_notes(mut self, mut notes: Vec<String>) -> Diagnostic<FileId> {
         self.notes.append(&mut notes);
+        self
+    }
+    
+    /// Add some notes to the diagnostic.
+    pub fn with_notes_iter(mut self, notes: impl IntoIterator<Item = String>>) -> Diagnostic<FileId> {
+        self.notes.extend(notes);
         self
     }
 }


### PR DESCRIPTION
It's unnecessary to require allocated vectors instead of just any iterator. With this change, you can use `with_labels_iter` in the example code (and in other code) with arrays instead of vectors to avoid extra heap allocations. The other methods were left untouched so this isn't a breaking change.